### PR TITLE
Invalid image

### DIFF
--- a/projects/ngx-image-compress/src/lib/image-compress.ts
+++ b/projects/ngx-image-compress/src/lib/image-compress.ts
@@ -178,6 +178,10 @@ export class ImageCompress {
 
       };
 
+      sourceImage.onerror = function (e) {
+        reject(e);
+      };
+
       sourceImage.src = imageDataUrlSource;
 
     });


### PR DESCRIPTION
Define the onerror event handler and reject the promise. This could happen if the image is invalid.

Fixes #60