### PR TITLE
UploadFile promise rejects when ChooseFileWindow closes without a fil…

### DIFF
--- a/projects/ngx-image-compress/src/lib/image-compress.ts
+++ b/projects/ngx-image-compress/src/lib/image-compress.ts
@@ -98,7 +98,8 @@ export class ImageCompress {
                 });
               }
             });
-        });
+        })
+        .catch(err => reject(err))
     });
 
   static fileToDataURL = (file: File): Promise<string> => {
@@ -136,10 +137,21 @@ export class ImageCompress {
         ($event.target as any as HTMLInputElement).value = '';
       });
 
+      let hasFile = false;
       render.listen(inputElement, 'change', ($event) => {
+        hasFile = true;
         const files: FileList = $event.target.files;
         resolve(files);
       });
+
+      window.addEventListener('focus', () => {
+        setTimeout(() => {
+          if (!hasFile) {
+            reject('CANCEL');
+          }
+        }, 500)
+      }, { once: true });
+
       inputElement.click();
     });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,10 @@
-import {Component} from '@angular/core';
-import {DataUrl, DOC_ORIENTATION, NgxImageCompressService, UploadResponse,} from 'ngx-image-compress';
+import { Component } from '@angular/core';
+import { DataUrl, DOC_ORIENTATION, NgxImageCompressService, UploadResponse } from 'ngx-image-compress';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss'],
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   imgResultBeforeCompress: DataUrl = '';
@@ -20,7 +20,7 @@ export class AppComponent {
   compressFile() {
     return this.imageCompress
       .uploadFile()
-      .then(({image, orientation}: UploadResponse) => {
+      .then(({ image, orientation }: UploadResponse) => {
         this.imgResultBeforeCompress = image;
         console.warn('Size in bytes was:', this.imageCompress.byteCount(image));
 
@@ -38,18 +38,21 @@ export class AppComponent {
       });
   }
 
-  uploadFile() {
-    return this.imageCompress
-      .uploadFile()
-      .then(
-        ({image, orientation}: UploadResponse) => {
-          this.imgResultUpload = image;
-          console.warn('DOC_ORIENTATION:', DOC_ORIENTATION[orientation]);
-          console.warn(
-            `${image.substring(0, 50)}... (${image.length} characters)`
-          );
+  async uploadFile() {
+    const res = await this.imageCompress.uploadFile()
+      .catch(error => {
+        if (error === 'CANCEL') {
+          console.log('UploadFile CANCELED');
+          return undefined as any;
         }
-      );
+        throw error;
+      });
+    if (res) {
+      const { image, orientation } = res;
+      this.imgResultUpload = image;
+      console.warn('DOC_ORIENTATION:', DOC_ORIENTATION[orientation]);
+      console.warn(`${image?.substring(0, 50)}... (${image?.length} characters)`);
+    }
   }
 
   uploadMultipleFiles() {
@@ -66,7 +69,7 @@ export class AppComponent {
   uploadAndResize() {
     return this.imageCompress
       .uploadFile()
-      .then(({image, orientation}: UploadResponse) => {
+      .then(({ image, orientation }: UploadResponse) => {
         console.warn('Size in bytes was:', this.imageCompress.byteCount(image));
         console.warn('Compressing and resizing to width 200px height 100px...');
 


### PR DESCRIPTION
UploadFile promise rejects when ChooseFileWindow closes without a file (operation canceled).

Today we no ways to know when a user closes the Choose-File-Window.
This patch makes UploadFile() promise returns a rejection with an error code equals to 'CANCEL' when that happens.