### PR TITLE
Add reject on cancel for 'uploadAndGetImageWithMaxSize' method

### DIFF
--- a/projects/ngx-image-compress/src/lib/image-compress.ts
+++ b/projects/ngx-image-compress/src/lib/image-compress.ts
@@ -270,7 +270,8 @@ export class ImageCompress {
 
     static byteCount = (imgString: DataUrl): number => encodeURI(imgString).split(/%..|./).length - 1;
 
-    static getImageMaxSize = async (maxSizeMb: number, debugMode: boolean, render: Renderer2): Promise<DataUrl> => {
+    static getImageMaxSize = async (maxSizeMb: number, debugMode: boolean, render: Renderer2,
+                                    rejectOnCancel = false): Promise<DataUrl> => {
         const MAX_TRIES = 10;
 
         const bytesToMB = (bytes: number) => (bytes / 1024 / 1024).toFixed(2);
@@ -279,7 +280,7 @@ export class ImageCompress {
             console.debug('NgxImageCompress - Opening upload window');
         }
 
-        let myFile: UploadResponse = (await ImageCompress.uploadFile(render, false)) as UploadResponse;
+        let myFile: UploadResponse = (await ImageCompress.uploadFile(render, false, rejectOnCancel)) as UploadResponse;
 
         let compressedFile;
 

--- a/projects/ngx-image-compress/src/lib/ngx-image-compress.service.ts
+++ b/projects/ngx-image-compress/src/lib/ngx-image-compress.service.ts
@@ -93,7 +93,7 @@ export class NgxImageCompressService {
      * If the size can't be reached, the best that can be reached will be returned in promise *rejection*
      * Put debugMode to true if you have some trouble to print some help using console.debug
      */
-    public uploadAndGetImageWithMaxSize(maxSizeMb: number = 1, debugMode = false): Promise<DataUrl> {
-        return ImageCompress.getImageMaxSize(maxSizeMb, debugMode, this.render);
+    public uploadAndGetImageWithMaxSize(maxSizeMb: number = 1, debugMode = false, rejectOnCancel = false): Promise<DataUrl> {
+        return ImageCompress.getImageMaxSize(maxSizeMb, debugMode, this.render, rejectOnCancel);
     }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -43,6 +43,16 @@
 </section>
 
 <hr/>
+
+<section>
+  <button (click)="uploadAndReturnWithMaxSizeWithLoading()" [disabled]="loadingCompression">
+    Uploading, Compressing, and returning with max size of 1 MegaByte (with loading)
+  </button>
+  <span *ngIf="loadingCompression">Loading...</span>
+  <img *ngIf="!loadingCompression && imgResultAfterResizeMaxWithLoading" [src]="imgResultAfterResizeMaxWithLoading" alt=""/>
+</section>
+
+<hr/>
 <section>
   For your tests you can download and upload the following images:
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,7 +12,9 @@ export class AppComponent {
     imgResultAfterResize: DataUrl = '';
     imgResultUpload: DataUrl = '';
     imgResultAfterResizeMax: DataUrl = '';
+    imgResultAfterResizeMaxWithLoading: DataUrl = '';
     imgResultMultiple: UploadResponse[] = [];
+    loadingCompression = false;
 
     constructor(private imageCompress: NgxImageCompressService) {}
 
@@ -68,12 +70,40 @@ export class AppComponent {
             },
             (result: string) => {
                 console.error(
-                    "The compression algorithm didn't succed! The best size we can do is",
+                    "The compression algorithm didn't succeed! The best size we can do is",
                     this.imageCompress.byteCount(result),
                     'bytes'
                 );
                 this.imgResultAfterResizeMax = result;
             }
         );
+    }
+
+    uploadAndReturnWithMaxSizeWithLoading() {
+        this.loadingCompression = true;
+        return this.imageCompress.uploadAndGetImageWithMaxSize(1, true, true).then(
+            (result: DataUrl) => {
+                this.imgResultAfterResizeMaxWithLoading = result;
+            },
+            (result: any) => {
+                if(result instanceof Error) {
+                    if((result as Error).message.includes("no file selected")) {
+                        console.log("No file selected");
+                    } else {
+                        console.error("Unknown error:", result);
+                    }
+                } else {
+                    let strResult = result as string;
+                    console.error(
+                        "The compression algorithm didn't succeed! The best size we can do is",
+                        this.imageCompress.byteCount(strResult),
+                        'bytes'
+                    );
+                    this.imgResultAfterResizeMaxWithLoading = strResult;
+                }
+            }
+        ).finally(() => {
+            this.loadingCompression = false;
+        });
     }
 }


### PR DESCRIPTION
Hello,

I need to detect when the user cancel the selection of file with the method `uploadAndGetImageWithMaxSize`.
Here is a PR where I add this option.  Notice that a default value has been added to be retro-compatible.

I add example in `app.component.html`.  I didn't add tests, but if it's required, I can do it.