### PR TITLE
feat(image type upload): adds support to .heic Files

### DIFF
--- a/projects/ngx-image-compress/src/lib/image-compress.ts
+++ b/projects/ngx-image-compress/src/lib/image-compress.ts
@@ -1,7 +1,7 @@
-import {Renderer2} from '@angular/core';
-import {DataUrl} from './models/data-url';
-import {DOC_ORIENTATION} from './models/DOC_ORIENTATION';
-import {UploadResponse} from './models/upload-response';
+import { Renderer2 } from '@angular/core';
+import { DataUrl } from './models/data-url';
+import { DOC_ORIENTATION } from './models/DOC_ORIENTATION';
+import { UploadResponse } from './models/upload-response';
 
 export class ImageCompress {
     getOrientation(file: File): Promise<DOC_ORIENTATION> {
@@ -113,7 +113,7 @@ export class ImageCompress {
             const inputElement = render.createElement('input');
             render.setStyle(inputElement, 'display', 'none');
             render.setProperty(inputElement, 'type', 'file');
-            render.setProperty(inputElement, 'accept', 'image/*');
+            render.setProperty(inputElement, 'accept', 'image/*, .heic');
 
             if (multiple) {
                 render.setProperty(inputElement, 'multiple', 'true');
@@ -154,7 +154,7 @@ export class ImageCompress {
             inputElement.id = 'upload-input' + new Date();
             inputElement.style.display = 'none';
             inputElement.setAttribute('type', 'file');
-            inputElement.setAttribute('accept', 'image/*');
+            inputElement.setAttribute('accept', 'image/*, .heic');
 
             if (multiple) {
                 inputElement.setAttribute('multiple', 'true');


### PR DESCRIPTION
Hi! Honestly I loved your library, it's amazing and it works like a charm.

The only issue I have found, is that it does not allow the upload of .heic files by iOS users. With this, even that the compress does not work, at least it uploads the file. In my case later I use the heic2any to convert it. With this change at least it allows it's upload.

Thank you so much!